### PR TITLE
feat: refactor garden advice into function. Fixes #3

### DIFF
--- a/garden_advice.py
+++ b/garden_advice.py
@@ -1,1 +1,18 @@
-print("Remember to water your plants daily!")
+def get_garden_advice(season):
+    """
+    Returns gardening advice based on the season.
+    """
+    advice = {
+        "spring": "Prune your roses and plant seeds!",
+        "summer": "Water deeply and mulch to retain moisture.",
+        "autumn": "Harvest vegetables and prepare soil for winter.",
+        "winter": "Protect plants from frost and plan next season."
+    }
+    return advice.get(season, "No advice available for this season.")
+
+if __name__ == "__main__":
+    print(get_garden_advice("spring"))
+    print(get_garden_advice("summer"))
+    print(get_garden_advice("autumn"))
+    print(get_garden_advice("winter"))
+    print(get_garden_advice("unknown"))  # Test fallback


### PR DESCRIPTION
Implements the refactoring requested in Issue #3:

- Created `get_garden_advice(season)` function that returns advice instead of printing
- Replaced hardcoded advice with a dictionary based on season
- Added simple unit tests by printing multiple seasons

Example usage:
```python
print(get_garden_advice("spring"))  # "Prune your roses and plant seeds!"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors to a `get_garden_advice(season)` function with dict-backed advice and a `__main__` demo including a fallback case.
> 
> - **Logic**:
>   - Introduces `get_garden_advice(season)` returning advice via a season-to-message dictionary with a default fallback.
> - **Script behavior** (`garden_advice.py`):
>   - Replaces standalone print with function usage.
>   - Adds `__main__` block printing advice for `spring`, `summer`, `autumn`, `winter`, and an unknown season.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b512b7e24a934e4d58b3664efb583f02973a1f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->