### PR TITLE
Refactor: add get_garden_advice function with month/season mapping (F…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # garden-app
+
+Simple gardening advice utility providing tips by month or season.
+
+## Usage
+
+Run directly as a CLI:
+
+```
+python garden_advice.py --month March
+python garden_advice.py --season spring
+```
+
+Or import in Python:
+
+```python
+from garden_advice import get_garden_advice
+
+print(get_garden_advice(month="April"))
+print(get_garden_advice(season="winter"))
+```
+
+## Tests
+
+```
+python -m unittest -v
+```
+
+## Repository link
+
+See `repo.txt` for the GitHub URL.

--- a/garden_advice.py
+++ b/garden_advice.py
@@ -1,18 +1,135 @@
-def get_garden_advice(season):
+"""
+garden_advice.py
+A simple script that gives gardening tips.
+"""
+
+# TODO: Refactor into a function called get_garden_advice() that returns
+# advice instead of just printing
+# TODO: Replace hardcoded advice with a dictionary that gives tips based on
+# season/month
+# TODO: Add simple unit tests for get_garden_advice()
+
+from typing import Optional
+
+
+ADVICE_BY_SEASON = {
+    "spring": (
+        "Start seeds indoors, prune shrubs, and prepare beds with compost."
+    ),
+    "summer": (
+        "Water early in the morning and mulch to retain soil moisture."
+    ),
+    "autumn": (
+        "Harvest late crops, plant cover crops, and clean up fallen leaves."
+    ),
+    "fall": (
+        "Harvest late crops, plant cover crops, and clean up fallen leaves."
+    ),
+    "winter": (
+        "Plan next season, protect perennials, and avoid overwatering indoors."
+    ),
+}
+
+
+ADVICE_BY_MONTH = {
+    "january": (
+        "Check indoor plants for pests and plan your seed order."
+    ),
+    "february": (
+        "Start cool-season seeds and clean/sterilize tools."
+    ),
+    "march": (
+        "Direct sow hardy greens; begin hardening off seedlings."
+    ),
+    "april": (
+        "Plant potatoes and onions; watch for late frosts."
+    ),
+    "may": (
+        "Transplant warm-season crops after last frost date."
+    ),
+    "june": (
+        "Stake tall plants and keep up with weeding."
+    ),
+    "july": (
+        "Harvest frequently and water deeply but infrequently."
+    ),
+    "august": (
+        "Sow fall crops like kale and radishes."
+    ),
+    "september": (
+        "Divide perennials and start collecting seeds."
+    ),
+    "october": (
+        "Plant garlic and add mulch to beds."
+    ),
+    "november": (
+        "Compost fallen leaves and clean up garden debris."
+    ),
+    "december": (
+        "Sharpen tools and map out crop rotation for spring."
+    ),
+}
+
+
+def normalize(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.strip().lower()
+
+
+def get_garden_advice(
+    month: Optional[str] = None, season: Optional[str] = None
+) -> str:
     """
-    Returns gardening advice based on the season.
+    Return gardening advice based on month or season.
+
+    If both month and season are provided, month-specific advice is
+    prioritized.
+    If neither matches, a generic reminder is returned.
+
+    Args:
+        month: Name of the month (e.g., "March"). Case-insensitive.
+        season: Name of the season ("spring", "summer", "autumn"/"fall",
+            "winter"). Case-insensitive.
+
+    Returns:
+        A short gardening advice string.
     """
-    advice = {
-        "spring": "Prune your roses and plant seeds!",
-        "summer": "Water deeply and mulch to retain moisture.",
-        "autumn": "Harvest vegetables and prepare soil for winter.",
-        "winter": "Protect plants from frost and plan next season."
-    }
-    return advice.get(season, "No advice available for this season.")
+    normalized_month = normalize(month)
+    normalized_season = normalize(season)
+
+    if normalized_month and normalized_month in ADVICE_BY_MONTH:
+        return ADVICE_BY_MONTH[normalized_month]
+
+    if normalized_season and normalized_season in ADVICE_BY_SEASON:
+        return ADVICE_BY_SEASON[normalized_season]
+
+    return (
+        "Remember to water your plants regularly and observe local conditions!"
+    )
+
+
+def _main() -> None:
+    # Minimal CLI for manual use
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Get gardening advice by month or season."
+    )
+    parser.add_argument(
+        "--month", type=str, help="Month name, e.g. 'March'", default=None
+    )
+    parser.add_argument(
+        "--season",
+        type=str,
+        help="Season name, e.g. 'spring'",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    advice = get_garden_advice(month=args.month, season=args.season)
+    print(advice)
+
 
 if __name__ == "__main__":
-    print(get_garden_advice("spring"))
-    print(get_garden_advice("summer"))
-    print(get_garden_advice("autumn"))
-    print(get_garden_advice("winter"))
-    print(get_garden_advice("unknown"))  # Test fallback
+    _main()


### PR DESCRIPTION
Fixes #5 - Implements get_garden_advice function with month/season mappings, CLI interface, and updated README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `get_garden_advice(month|season)` with month/season mappings, a minimal CLI, and updated README usage/tests.
> 
> - **Core**:
>   - Add `get_garden_advice(month=None, season=None)` in `garden_advice.py` with month- and season-based advice maps, case-insensitive normalization, and generic fallback; month takes precedence when both provided.
> - **CLI**:
>   - Introduce `_main()` using `argparse` with `--month` and `--season` flags; script now prints advice via CLI.
> - **Docs**:
>   - Expand `README.md` with CLI examples, import usage, and test command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dc625abd5873461eb9657b1c700cac04458e4c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->